### PR TITLE
Fixes close brace for SASS mapping.

### DIFF
--- a/tasks/json_to_sass.js
+++ b/tasks/json_to_sass.js
@@ -58,6 +58,7 @@ var parseJSON = function (path, src) {
             .replace(/((?!#).{1}|^.{0}){/g, '$1(')
             .replace(/\[/g, '(')
             .replace(/}(?=,|$|\n|})/g, ')')
+            .replace(/\}/g, ')');
             .replace(/\]/g, ')');
 
         map = fixColors(map);


### PR DESCRIPTION
When building a SASS map via JSON that looks like:
<code>
{
"glyph_list": [{
        "title": "right-arrow",
        "code": "e0ae"
    }, {
        "title": "left-arrow",
        "code": "e0d5"
    }]
}
</code>

It compiles to:
<code>
$glyph_list:(
              (title:"right-arrow",code:e0ae),
              (title:"left-arrow",code:e0d5}
);
</code>

This update would remove the incorrect, and breaking, "}" at the end of the object map.
